### PR TITLE
Add __init__ to Models dir, and ignore *.pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .DS_Store
+*.pyc


### PR DESCRIPTION
If there is no __init__.py present in the Models dir, the main script fails with:
ImportError: No module named Models.LIF_Interactive
(in Python 2.7)